### PR TITLE
Optimize force calculation: special optimization for force calculation if types of two atoms are the same.

### DIFF
--- a/src/hip_eam_device.h
+++ b/src/hip_eam_device.h
@@ -45,8 +45,11 @@ namespace hip_pot {
    * (single atom type).
    * Otherwise, the api `hipToForce` will be called (normal atom types case).
    * \tparam T type of float point number. (currently, it can only be double).
+   * \tparam ALLOW_WARP_DIVERGENCE In CUDA, warp divergence may cause poor performance.
+   * By setting ALLOW_WARP_DIVERGENCE to false can avoid this side effect,
+   * if there are atom pairs having the same types and other atom pairs having different types in a warp.
    */
-  template <typename T>
+  template <typename T, bool ALLOW_WARP_DIVERGENCE = true>
   __device__ HIP_POT_INLINE T hipToForceAdaptive(const atom_type::_type_prop_key key_from,
                                                  const atom_type::_type_prop_key key_to, const T dist2, const T df_from,
                                                  const T df_to);

--- a/src/hip_eam_device.h
+++ b/src/hip_eam_device.h
@@ -24,9 +24,36 @@ namespace hip_pot {
   __device__ HIP_POT_INLINE double hipToForce(const atom_type::_type_prop_key key_from,
                                               const atom_type::_type_prop_key key_to, const double dist2,
                                               const double df_from, const double df_to);
+
   /**
-   * compute the contribution to electron charge density from atom j of type {@var _atom_key} at location of one atom i.
-   * whose distance is specified by {@var dist2}
+   * Eam force computation api for single atom type.
+   * What is "single atom type": types of i and j is the same when calculating force contribution from atom j to atom i.
+   * In this case, the api implementation can be simplified for better performance.
+   * \tparam T type of float point number. (currently, it can only be double).
+   * \param key the type of atom i and j.
+   * \param dist2 distance^2 of the two atoms.
+   * \param df_from derivative of embedded energy of atom j.
+   * \param df_to derivative of embedded energy of atom i.
+   */
+  template <typename T>
+  __device__ HIP_POT_INLINE T hipToForceSingleType(const atom_type::_type_prop_key key, const T dist2, const T df_from,
+                                                   const T df_to);
+
+  /**
+   * Eam force computation api for both normal atom types and single atom type.
+   * In its implementation, it will call api `hipToForceSingleType` if key_from and key_to are the same
+   * (single atom type).
+   * Otherwise, the api `hipToForce` will be called (normal atom types case).
+   * \tparam T type of float point number. (currently, it can only be double).
+   */
+  template <typename T>
+  __device__ HIP_POT_INLINE T hipToForceAdaptive(const atom_type::_type_prop_key key_from,
+                                                 const atom_type::_type_prop_key key_to, const T dist2, const T df_from,
+                                                 const T df_to);
+
+  /**
+   * compute the contribution to electron charge density from atom j of type {@var _atom_key} at location of one
+   * atom i. whose distance is specified by {@var dist2}
    * @param _atom_key atom type of atom j.
    * @param dist2 the square of the distance between atom i and atom j.
    * @return the contribution to electron charge density from atom j.

--- a/src/hip_eam_device.inl
+++ b/src/hip_eam_device.inl
@@ -37,6 +37,48 @@ __device__ HIP_POT_INLINE double hip_pot::hipToForce(const atom_type::_type_prop
   return fpair;
 }
 
+/**
+ * special optimization for force calculation if "from type" and "to type" are the same.
+ */
+template <typename T>
+__device__ HIP_POT_INLINE T hip_pot::hipToForceSingleType(const atom_type::_type_prop_key key, const T dist2,
+                                                          const T df_from, const T df_to) {
+  const T r = sqrt(dist2);
+  const _device_spline_data phi_s = devicePhiSplineByType(key, key, r);
+  const _device_spline_data ele_s = deviceRhoSpline(key, r);
+
+  const T z2 = ((phi_s.spline[3] * phi_s.p + phi_s.spline[4]) * phi_s.p + phi_s.spline[5]) * phi_s.p + phi_s.spline[6];
+  // z2 = phi*r
+  const T z2p = (phi_s.spline[0] * phi_s.p + phi_s.spline[1]) * phi_s.p + phi_s.spline[2];
+  // z2p = (phi * r)' = (phi' * r) + phi
+
+  const T rho_p = (ele_s.spline[0] * ele_s.p + ele_s.spline[1]) * ele_s.p + ele_s.spline[2];
+
+  const T recip = 1.0 / r;
+  const T phi = z2 * recip;                 // pair potential energy
+  const T phip = z2p * recip - phi * recip; // phip = phi' = (z2p - phi)/r
+
+  const T psip = (df_from + df_to) * rho_p + phip;
+  const T fpair = -psip * recip;
+
+  return fpair;
+}
+
+/**
+ * select hipToForce api between single type and double type version.
+ * @tparam T type of float point number: float or double.
+ */
+template <typename T>
+__device__ HIP_POT_INLINE T hip_pot::hipToForceAdaptive(const atom_type::_type_prop_key key_from,
+                                                        const atom_type::_type_prop_key key_to, const T dist2,
+                                                        const T df_from, const T df_to) {
+  if (key_from == key_to) {
+    return hipToForceSingleType<T>(key_from, dist2, df_from, df_to);
+  } else {
+    return hip_pot::hipToForce(key_from, key_to, dist2, df_from, df_to);
+  }
+}
+
 __device__ HIP_POT_INLINE double hip_pot::hipChargeDensity(const atom_type::_type_prop_key _atom_key,
                                                            const double dist2) {
   const double r = sqrt(dist2);
@@ -61,3 +103,14 @@ __device__ HIP_POT_INLINE double hip_pot::hipPairPotential(const atom_type::_typ
   const double phi_r = ((s.spline[3] * s.p + s.spline[4]) * s.p + s.spline[5]) * s.p + s.spline[6]; // pair_pot * r
   return phi_r / r;
 }
+
+// make instance of template functions:
+template __device__ HIP_POT_INLINE double hip_pot::hipToForceSingleType<double>(const atom_type::_type_prop_key key,
+                                                                                const double dist2,
+                                                                                const double df_from,
+                                                                                const double df_to);
+
+template __device__ HIP_POT_INLINE double hip_pot::hipToForceAdaptive<double>(const atom_type::_type_prop_key key_from,
+                                                                              const atom_type::_type_prop_key key_to,
+                                                                              const double dist2, const double df_from,
+                                                                              const double df_to);

--- a/src/hip_eam_device.inl
+++ b/src/hip_eam_device.inl
@@ -66,13 +66,16 @@ __device__ HIP_POT_INLINE T hip_pot::hipToForceSingleType(const atom_type::_type
 
 /**
  * select hipToForce api between single type and double type version.
- * @tparam T type of float point number: float or double.
+ * \tparam T type of float point number: float or double.
+ * \tparam ALLOW_WARP_DIVERGENCE In CUDA, warp divergence may cause poor performance.
+ * By setting ALLOW_WARP_DIVERGENCE to false can avoid this side effect,
+ * if there are atom pairs having the same types and other atom pairs having different types in a warp.
  */
-template <typename T>
+template <typename T, bool ALLOW_WARP_DIVERGENCE = true>
 __device__ HIP_POT_INLINE T hip_pot::hipToForceAdaptive(const atom_type::_type_prop_key key_from,
                                                         const atom_type::_type_prop_key key_to, const T dist2,
                                                         const T df_from, const T df_to) {
-  if (key_from == key_to) {
+  if (ALLOW_WARP_DIVERGENCE && key_from == key_to) {
     return hipToForceSingleType<T>(key_from, dist2, df_from, df_to);
   } else {
     return hip_pot::hipToForce(key_from, key_to, dist2, df_from, df_to);
@@ -110,7 +113,11 @@ template __device__ HIP_POT_INLINE double hip_pot::hipToForceSingleType<double>(
                                                                                 const double df_from,
                                                                                 const double df_to);
 
-template __device__ HIP_POT_INLINE double hip_pot::hipToForceAdaptive<double>(const atom_type::_type_prop_key key_from,
-                                                                              const atom_type::_type_prop_key key_to,
-                                                                              const double dist2, const double df_from,
-                                                                              const double df_to);
+template __device__ HIP_POT_INLINE double
+hip_pot::hipToForceAdaptive<double, false>(const atom_type::_type_prop_key key_from,
+                                           const atom_type::_type_prop_key key_to, const double dist2,
+                                           const double df_from, const double df_to);
+template __device__ HIP_POT_INLINE double
+hip_pot::hipToForceAdaptive<double, true>(const atom_type::_type_prop_key key_from,
+                                          const atom_type::_type_prop_key key_to, const double dist2,
+                                          const double df_from, const double df_to);

--- a/tests/unit/device/eam_calc_test_device.cpp
+++ b/tests/unit/device/eam_calc_test_device.cpp
@@ -64,6 +64,16 @@ __global__ void _kernelEamForce(atom_type::_type_prop_key *key_from, atom_type::
   }
 }
 
+__global__ void _kernelEamForceSingleType(atom_type::_type_prop_key *key_from, atom_type::_type_prop_key *key_to,
+                                          double *df_from, double *df_to, double *dist2, double *forces, size_t len) {
+  int id = hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x; // global thread id
+  int threads = hipGridDim_x * hipBlockDim_x;              // total threads
+  for (int i = id; i < len; i += threads) {
+    forces[i] = hip_pot::hipToForceAdaptive(key_from[i], key_to[i], dist2[i], df_from[i], df_to[i]);
+  }
+}
+
+template <bool SINGLE_TYPE>
 void deviceForce(atom_type::_type_prop_key *key_from, atom_type::_type_prop_key *key_to, double *df_from, double *df_to,
                  double *dist2, double *forces, size_t len) {
   const size_t B = 512; // blocks
@@ -89,8 +99,13 @@ void deviceForce(atom_type::_type_prop_key *key_from, atom_type::_type_prop_key 
   HIP_CHECK(hipMemcpy(deviceDfTo, df_to, len * sizeof(double), hipMemcpyHostToDevice));
   HIP_CHECK(hipMemcpy(deviceDist2, dist2, len * sizeof(double), hipMemcpyHostToDevice));
 
-  hipLaunchKernelGGL(_kernelEamForce, dim3(B, 1), dim3(T, 1), 0, 0, deviceKeyFrom, deviceKeyTo, deviceDfFrom,
-                     deviceDfTo, deviceDist2, deviceForces, len);
+  if (SINGLE_TYPE) {
+    hipLaunchKernelGGL(_kernelEamForceSingleType, dim3(B, 1), dim3(T, 1), 0, 0, deviceKeyFrom, deviceKeyTo,
+                       deviceDfFrom, deviceDfTo, deviceDist2, deviceForces, len);
+  } else {
+    hipLaunchKernelGGL(_kernelEamForce, dim3(B, 1), dim3(T, 1), 0, 0, deviceKeyFrom, deviceKeyTo, deviceDfFrom,
+                       deviceDfTo, deviceDist2, deviceForces, len);
+  }
 
   HIP_CHECK(hipMemcpy(forces, deviceForces, len * sizeof(double), hipMemcpyDeviceToHost));
 
@@ -101,6 +116,12 @@ void deviceForce(atom_type::_type_prop_key *key_from, atom_type::_type_prop_key 
   HIP_CHECK(hipFree(deviceDist2));
   HIP_CHECK(hipFree(deviceForces));
 }
+
+template void deviceForce<true>(atom_type::_type_prop_key *key_from, atom_type::_type_prop_key *key_to, double *df_from,
+                                double *df_to, double *dist2, double *forces, size_t len);
+
+template void deviceForce<false>(atom_type::_type_prop_key *key_from, atom_type::_type_prop_key *key_to,
+                                 double *df_from, double *df_to, double *dist2, double *forces, size_t len);
 
 __global__ void _kernelEamChargeDensity(const atom_type::_type_prop_key *keys, const double *dist2, double *rhos,
                                         size_t len) {

--- a/tests/unit/device/eam_calc_test_device.h
+++ b/tests/unit/device/eam_calc_test_device.h
@@ -9,6 +9,7 @@
 
 void checkPotSplinesCopy(int ele_size, int data_size);
 
+template <bool SINGLE_TYPE>
 void deviceForce(atom_type::_type_prop_key *key_from, atom_type::_type_prop_key *key_to, double *df_from, double *df_to,
                  double *dist2, double *forces, size_t len);
 

--- a/tests/unit/hip_pot_test.cpp
+++ b/tests/unit/hip_pot_test.cpp
@@ -70,7 +70,41 @@ TEST_F(EamPotTest, hip_pot_force_test) {
   };
   double force_device[LEN];
 
-  deviceForce(key_from, key_to, df_from, df_to, dist2, force_device, LEN);
+  // test hip_pot::hipToForce
+  deviceForce<false>(key_from, key_to, df_from, df_to, dist2, force_device, LEN);
+  for (int i = 0; i < LEN; i++) {
+    double force_host = _pot->toForce(key_from[i], key_to[i], dist2[i], df_from[i], df_to[i]);
+    EXPECT_DOUBLE_EQ(force_host, force_device[i]);
+  }
+  hip_pot::destroyDevicePotTables(d_pot);
+}
+
+// in force computation, the two atoms have the same type.
+// then, the computation can be simplified (see kernel `hip_pot::hipToForceWrapper`).
+TEST_F(EamPotTest, hip_pot_force_single_type_test) {
+  std::vector<atom_type::_type_atomic_no> _pot_types(ELE_SIZE);
+  for (int i = 0; i < ELE_SIZE; i++) {
+    _pot_types[i] = prop_key_list[i];
+  }
+  // init
+  hip_pot::_type_device_pot d_pot = hip_pot::potCopyHostToDevice(_pot, _pot_types);
+  hip_pot::assignDevicePot(d_pot);
+
+  constexpr size_t LEN = 8;
+  const double lattice_const = 2.85532 * 2.85532;
+
+  atom_type::_type_prop_key key_from[LEN] = {0, 1, 2, 0, 0, 1, 1, 2};
+  atom_type::_type_prop_key key_to[LEN] = {0, 1, 2, 1, 2, 0, 2, 1};
+  double df_from[LEN] = {0.1, 0.15, 0.13, 0.12, 0.23, 0.45, 0.2, 0.13};
+  double df_to[LEN] = {0.23, 0.43, 0.12, 0.26, 0.24, 0.17, 0.65, 0.45};
+  double dist2[LEN] = {
+      1.5 * lattice_const, 4.1 * lattice_const,  5.5 * lattice_const,  3.1 * lattice_const,
+      3.5 * lattice_const, 4.89 * lattice_const, 6.34 * lattice_const, 7.14 * lattice_const,
+  };
+  double force_device[LEN];
+
+  // test hip_pot::hipToForceWrapper
+  deviceForce<true>(key_from, key_to, df_from, df_to, dist2, force_device, LEN);
   for (int i = 0; i < LEN; i++) {
     double force_host = _pot->toForce(key_from[i], key_to[i], dist2[i], df_from[i], df_to[i]);
     EXPECT_DOUBLE_EQ(force_host, force_device[i]);


### PR DESCRIPTION
add new api `hipToForceSingleType` for force calc when two atoms keep the same type.
Besides, we also provide another api `hipToForceAdaptive` for adaptively api selection between `hipToForceSingleType` and `hipToForce`.